### PR TITLE
Bugfix/setup build protos

### DIFF
--- a/scripts/build_protos.py
+++ b/scripts/build_protos.py
@@ -37,7 +37,8 @@ def build_protos(input_path='build/protobuf', output_path='senseye_api_client/pr
     output_path.mkdir(exist_ok=True, parents=True)
 
     print("Building Protos...")
-    print(f"Output: {output_path}")
+    print(f"Protos path: {input_path}")
+    print(f"Output path: {output_path}")
 
     # Get proto file list
     proto_files = [str(f) for f in input_path.glob('**/*.proto')]

--- a/scripts/build_protos.py
+++ b/scripts/build_protos.py
@@ -40,21 +40,27 @@ def build_protos(input_path='build/protobuf', output_path='senseye_api_client/pr
     print(f"Output: {output_path}")
 
     # Get proto file list
-    proto_files = [str(f) for f in input_path.glob('*.proto')]
-    print(input_path)
+    proto_files = [str(f) for f in input_path.glob('**/*.proto')]
+
     # Build Protos with protoc module
     protoc.main([
         '', # Needed :(
+        # Add Google's base protos
+        f'-I{Path(protoc.__file__).parent / "_proto"}',
+        # Add Senseye's protos
+        f'-I{input_path}',
         f'--python_out={output_path}',
         f'--grpc_python_out={output_path}',
-        f'-I{input_path}',
         *proto_files
     ])
 
     # Replace module names
-    for file in output_path.glob('*pb2*.py'):
+    for file in output_path.glob('**/*pb2*.py'):
         with open(file, 'r') as f:
             content = re.sub(r'^(import.*_pb2)', r'from . \1', f.read(), flags=re.M)
 
         with open(file, 'w') as f:
             f.write(content)
+
+        with open(output_path / 'senseye/__init__.py', 'w') as f:
+            f.write('\n')

--- a/senseye_api_client/api.py
+++ b/senseye_api_client/api.py
@@ -1,13 +1,14 @@
-import os
-import jwt
 import grpc
-import queue
+import jwt
 import logging
-from senseye_cameras import Stream
+import os
+import queue
 
-from . proto.gateway_service_pb2_grpc import GatewayStub
-from . proto.common_pb2 import VideoStreamRequest, VideoStaticRequest, CvModel
+from senseye.common.common_pb2 import VideoStreamRequest, VideoStaticRequest, CvModel
+from senseye.gateway.gateway_service_pb2_grpc import GatewayStub
+from senseye_cameras import Stream
 from . utils import video_config, load_config
+
 
 log = logging.getLogger(__name__)
 

--- a/senseye_api_client/utils.py
+++ b/senseye_api_client/utils.py
@@ -1,10 +1,11 @@
 import os
-from pathlib import Path
 import uuid
+from pathlib import Path
 
 import yaml
 
-from . proto.common_pb2 import VideoConfig, CvModel
+from senseye.common.common_pb2 import VideoConfig, CvModel
+
 
 # Default Config Path ~/.config/senseye.yaml
 DEFAULT_CONFIG_PATH = (Path.home() / '.config' / 'senseye.yaml').absolute()

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,21 @@
+from pathlib import Path
 from setuptools import setup
 from setuptools.command.build_py import build_py
 
-from pathlib import Path
-from zipfile import ZipFile
-from io import BytesIO
+
+PROTO_VERSION = 'release/v0.3.1'
 
 readme = str(Path(Path(__file__).parent.absolute(), 'README.md'))
 long_description = open(readme, encoding='utf-8').read()
 
-PROTO_VERSION = 'release/v0.3.1'
+# Temporary directory to build 'senseye' package
+Path('build/senseye').mkdir(exist_ok=True, parents=True)
 
 
 class BuildPyCommand(build_py):
-    """Build Hook"""
-
+    """
+    Build Hook
+    """
     def run(self):
         from scripts.build_protos import get_protos, build_protos
 
@@ -23,10 +25,10 @@ class BuildPyCommand(build_py):
         # Build Proto Files
         build_protos(
             input_path='build/protobuf',
-            output_path='senseye_api_client/proto'
+            output_path='build'
         )
-        build_py.run(self)
 
+        build_py.run(self)
 
 setup(
     name='senseye-api-client',
@@ -36,12 +38,16 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     packages=[
+        'senseye',
         'senseye_api_client',
         'senseye_api_client.interceptors',
-        'senseye_api_client.proto',
     ],
     package_dir={
+        'senseye': 'build/senseye',
         'senseye_api_client': 'senseye_api_client',
+    },
+    package_data={
+        "senseye": ["**/*.py"],
     },
     install_requires=[
         'grpcio',
@@ -57,5 +63,5 @@ setup(
     cmdclass={
         # Custom Build hook
         'build_py': BuildPyCommand,
-    },
+    }
 )


### PR DESCRIPTION
With our new protobuf file structure (/google, /senseye), there were a few updates that had to be made in order to properly build/install again.

1. `build_protos` updated to scan for .proto files recursively and also properly handle Google's protos
2. `import . proto.*` no longer works. Digging into this i decided to rework/refactor `senseye_api_client.proto` package to `senseye`. I think this is the direction we'll eventually wanna go in anyways (correct me if i'm wrong tho)
3. With (2), this also removes the need to run `python setup.py build_py` beforehand; we can simply run `pip install .` and everything will be built. However, we'll be losing out on the built protos remaining available under `senseye_api_client/protos` (not sure how important that is)

